### PR TITLE
Fixed Path Traversal bug on webrepl

### DIFF
--- a/webrepl.js
+++ b/webrepl.js
@@ -80,7 +80,7 @@ ReplHttpServer.prototype.route = function(req, res) {
     var stream = this.stream;
     var replServer = this.replServer;
     
-    if(req.url.includes('../')){
+    if(req.url.includes('..')){
         console.log("Error resolving context request: " + req.url);
         res.writeHeader(500);
         res.end();

--- a/webrepl.js
+++ b/webrepl.js
@@ -79,6 +79,12 @@ ReplHttpServer.prototype.start = function(port) {
 ReplHttpServer.prototype.route = function(req, res) {
     var stream = this.stream;
     var replServer = this.replServer;
+    
+    if(req.url.includes('../')){
+        console.log("Error resolving context request: " + req.url);
+        res.writeHeader(500);
+        res.end();
+    }
 
     req.on('error', function() { /* Ignore Errors */ });
     res.on('error', function() { /* Ignore Errors */ });


### PR DESCRIPTION
### 📊 Metadata *

Path traversal bug

#### Bounty URL:  https://www.huntr.dev/bounties/1-npm-webrepl/

### ⚙️ Description *

webrepl is a Serve a repl for a node process via a web console, this package is vulnerable to Directory Traversal, which may allow access to sensitive files and data on the server.

For example, requesting the following url `/../../etc/passwd` would result in `/etc/passwd` leaking.

### 💻 Technical Description *

The path traversal issue exists because it fails to validate the `req.url` to check for path traversal payloads. The fix can be implemented by preventing requests with `../` in it's URL.

### 🐛 Proof of Concept (PoC) *

Create a index.js with:
```js
var webrepl = require('webrepl');
webrepl.start(8080);
```

And try to GET: `curl --path-as-is 'localhost:8080/../../../../../../../etc/passwd'`

![image](https://user-images.githubusercontent.com/16708391/92589530-4b553100-f2b8-11ea-9715-b7134e0e7969.png)


### 🔥 Proof of Fix (PoF) *

After the fix, it drops the connection with request error 500. Hence the path traversal issue is mitigated.

![image](https://user-images.githubusercontent.com/16708391/92589651-7e97c000-f2b8-11ea-991e-83efc4e9130f.png)


### 👍 User Acceptance Testing (UAT)

Validated the path for bad URLs, no breaking changes implemented.
