### PR TITLE
[FIX] Path traversal in "webrepl"

### DIFF
--- a/webrepl.js
+++ b/webrepl.js
@@ -83,6 +83,8 @@ ReplHttpServer.prototype.route = function(req, res) {
     req.on('error', function() { /* Ignore Errors */ });
     res.on('error', function() { /* Ignore Errors */ });
 
+    req.url = req.url.replace(/(\.\.)/g, '');
+    
     var match = null;
     if (req.url.match(/^\/repl/)) {
         if (req.method === 'GET') {


### PR DESCRIPTION
#### Bounty URL: https://www.huntr.dev/bounties/1-npm-wrlc

### ⚙️ Description *

The `webrepl` server was vulnerable against `path traversal` attacks made through the `../` attack vector.
This allowed malicious authors to `read sensitive files` under the `server root` directory, like `/etc/passwd`.

### 💻 Technical Description *

I simply `removed` all the `..` dots in order to avoid `path traversal` issues :smile:

### 🐛 Proof of Concept (PoC) *

1. Create the `poc.js` file

```js
var webrepl = require('webrepl');
webrepl.start(8080);
```
1. `node poc.js`
2. `curl --path-as-is http://localhost:8080/../../../../../../../../../../../../etc/passwd`

The `/etc/passwd` file is shown :cry:

### 🔥 Proof of Fix (PoF) *

Same steps with fixed version doesn't show `/etc/passwd` :smile:

### 👍 User Acceptance Testing (UAT)

All OK 👍 

![worked](https://user-images.githubusercontent.com/33063403/92598143-b39c1680-f2a8-11ea-9858-8dec2e982967.png)
